### PR TITLE
Overloads now work.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "c-cpp-definition-generator",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -409,13 +409,24 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npm.taobao.org/https-proxy-agent/download/https-proxy-agent-2.2.1.tgz",
-			"integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.1.0",
+				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+					"dev": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				}
 			}
 		},
 		"inflight": {

--- a/src/cppext.ts
+++ b/src/cppext.ts
@@ -53,16 +53,16 @@ export class SourceFile {
     }
 
     /**
-     * // TODO c++ overload
-     * find if exist a definition with same name
+     * find if exist a definition with same name and params
      * @param declaration declaration snippet
      * @param scopes for cpp, definition prefix
      */
     private _getDefinitionLine(declaration: string, scopes: string[]): number {
         let definition = semantics.getDefinition(declaration, scopes);
         let identifier = definition.getIdentifier();
+        
         // exactly identifier
-        let regexIdentifier = new RegExp('\(^|\\s+\)' + identifier + '\\s*\\(');
+        let regexIdentifier = new RegExp('\(^|\\s+\)' + identifier + '\\s*\\(' + definition.params);
         let line = 0;
         let text = '';
         while (line < this._doc!.lineCount) {


### PR DESCRIPTION
Added params to _getDefinitionLine regexIdentifier so that a line needs to match the
correct overload to be returned.